### PR TITLE
changing lambda runtime from 10 to 12

### DIFF
--- a/lib/kendra-query-api-stack.ts
+++ b/lib/kendra-query-api-stack.ts
@@ -11,7 +11,7 @@ export class KendraQueryApiStack extends core.Stack {
     const bucket = new s3.Bucket(this, "KendraQueryAPIStore");
 
     const handler = new lambda.Function(this, "KendraQueryAPIHandler", {
-      runtime: lambda.Runtime.NODEJS_10_X, 
+      runtime: lambda.Runtime.NODEJS_12_X, 
       code: lambda.Code.asset("lambda"),
       handler: "kendraQuery.main"
     });


### PR DESCRIPTION
*Issue #1  :*

*Description of changes:* changed lambda runtime from 10 to 12 as 10 is no longer supported and fails deployment


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
